### PR TITLE
Make syntax imports more precise

### DIFF
--- a/modules/core/src/main/scala/volga/syntax/SymonOps.scala
+++ b/modules/core/src/main/scala/volga/syntax/SymonOps.scala
@@ -1,0 +1,9 @@
+package volga.syntax
+
+import volga.SemigropalCat
+
+trait SymonOps {
+  implicit class Ops[P[_,_], A, B](private val pab: P[A, B]) {
+    def split[C, D, x[_, _]](pcd: P[C, D])(implicit sem: SemigropalCat[P, x]): P[A x C, B x D] = sem.split(pab, pcd)
+  }
+}

--- a/modules/core/src/main/scala/volga/syntax/arr.scala
+++ b/modules/core/src/main/scala/volga/syntax/arr.scala
@@ -3,6 +3,8 @@ package syntax
 
 object arr extends Arr.ToArrOps
 object cat extends Cat.ToCatOps
+object plus extends ArrPlus.ToArrPlusOps
+object choice extends ArrChoice.ToArrChoiceOps
 object symmon {
   implicit class SymMonOps[P[_, _], A, B](private val pab: P[A, B]) extends AnyVal {
     def split[C, D, x[_, _]](pcd: P[C, D])(implicit sem: SemigropalCat[P, x]): P[A x C, B x D] = sem.split(pab, pcd)

--- a/modules/core/src/main/scala/volga/syntax/arr.scala
+++ b/modules/core/src/main/scala/volga/syntax/arr.scala
@@ -1,12 +1,15 @@
 package volga
 package syntax
 
+trait all extends Arr.ToArrOps
+  with Cat.ToCatOps
+  with ArrPlus.ToArrPlusOps
+  with ArrChoice.ToArrChoiceOps
+  with SymonOps
+
 object arr extends Arr.ToArrOps
 object cat extends Cat.ToCatOps
 object plus extends ArrPlus.ToArrPlusOps
 object choice extends ArrChoice.ToArrChoiceOps
-object symmon {
-  implicit class SymMonOps[P[_, _], A, B](private val pab: P[A, B]) extends AnyVal {
-    def split[C, D, x[_, _]](pcd: P[C, D])(implicit sem: SemigropalCat[P, x]): P[A x C, B x D] = sem.split(pab, pcd)
-  }
-}
+object symmon extends SymonOps
+object all extends all


### PR DESCRIPTION
I'm not really sure if `all` import is needed, but I think that at least it makes the "getting started "phase more convenient.